### PR TITLE
Drop support for Ruby 2.6

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation

--- a/pinhole.gemspec
+++ b/pinhole.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "Tracker-based image viewer for GNOME"
   spec.homepage = "http://www.github.com/mvz/pinhole"
   spec.license = "GPL-2+"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.metadata["rubygems_mfa_required"] = "true"
 


### PR DESCRIPTION
- Require Ruby 2.7
- Make RuboCop target Ruby 2.7
