### PR TITLE
Replace soft-deprecated runtime dependency specification

### DIFF
--- a/pinhole.gemspec
+++ b/pinhole.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
 
   spec.files = File.read("Manifest.txt").split
 
-  spec.add_runtime_dependency "gir_ffi-gtk", "~> 0.17.0"
-  spec.add_runtime_dependency "gir_ffi-tracker", "~> 0.17.0"
+  spec.add_dependency "gir_ffi-gtk", "~> 0.17.0"
+  spec.add_dependency "gir_ffi-tracker", "~> 0.17.0"
 
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"


### PR DESCRIPTION
Using add_runtime_dependency is soft-deprecated and now flagged by RuboCop.
