### PR TITLE
Remove scheduled CI runs

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,8 +9,6 @@ name: CI
     branches: [master]
   pull_request:
     branches: [master]
-  schedule:
-    - cron: '16 4 12 * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
These schedules make GitHub disable the whole workflow when activity is low, and I'd rather the jobs were run whenever a pull request lands.